### PR TITLE
[Feature] Handle duplicates and point user to the link if it already exists

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+# Environment
+ENVIRONMENT='development'
+
+#test
+TEST_DB =  'sqlite:///:memory:'
+TEST_BASE_URL = 'http://www.shortly.com'
+
+#DEV
+DEV_DB = 'sqlite:///database.db'
+DEV_BASE_URL = 'http://127.0.0.1:5000'
+
+#PROD

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aniso8601==10.0.1
 blinker==1.9.0
 click==8.3.0
+dotenv==0.9.9
 Flask==3.1.2
 Flask-RESTful==0.3.10
 Flask-SQLAlchemy==3.1.1
@@ -13,6 +14,7 @@ pluggy==1.6.0
 Pygments==2.19.2
 pytest==8.4.2
 pytest-flask==1.3.0
+python-dotenv==1.1.1
 pytz==2025.2
 six==1.17.0
 SQLAlchemy==2.0.43

--- a/shortly/__init__.py
+++ b/shortly/__init__.py
@@ -1,19 +1,31 @@
+from dotenv import load_dotenv
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_restful import Api
+import os
 
 db = SQLAlchemy()
 
-def create_app(testing=False):
+def create_app():
+    load_dotenv()
     app = Flask(__name__)
 
-    if testing:
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    else:
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///database.db'
+    env = os.getenv("ENVIRONMENT", "development")
+
+    if env == "testing":
+        app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv("TEST_DB")
+        app.config['BASE_URL'] = os.getenv("TEST_BASE_URL")
+        app.config['TESTING'] = True
+    elif env == "production":
+        app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv("PROD_DB")
+        app.config['BASE_URL'] = os.getenv("PROD_BASE_URL")
+        app.config['TESTING'] = False
+    else:  # development
+        app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv("DEV_DB")
+        app.config['BASE_URL'] = os.getenv("DEV_BASE_URL")
+        app.config['TESTING'] = False
 
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    app.config['TESTING'] = testing
 
     db.init_app(app)
     api = Api(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
+import os
 import pytest 
 from shortly import create_app, db
 
 @pytest.fixture
 def app():
-    app = create_app(testing=True)
+    os.environ["ENVIRONMENT"] = "testing"
+    app = create_app()
     with app.app_context():
         db.create_all()
         yield app


### PR DESCRIPTION
This update handles duplicates on the application side rather than allowing it to get to Database. It checks for an existing entry in the database with that url. If it exists, it directs the user to use the existing shortened URL :). Also added environment variables file in case I decide to host in the future. Tested Manually and with unit tests.

1. Adding new entry to DB
<img width="874" height="434" alt="Screenshot 2025-10-08 at 6 07 04 PM" src="https://github.com/user-attachments/assets/52d5df52-bf8b-4ee5-91a9-95196da23b74" />

2. Attempting to add same URL, 409 error and direct user to existing short URL
<img width="875" height="388" alt="Screenshot 2025-10-08 at 6 08 25 PM" src="https://github.com/user-attachments/assets/5386b937-b164-43b5-924f-b73f4435b39f" />

3. Using short URL brings us to the entry (link will be changed to actual short link in future when redirects are functional- right now just links back to the entry in DB)
<img width="874" height="266" alt="Screenshot 2025-10-08 at 6 08 49 PM" src="https://github.com/user-attachments/assets/6d184350-5884-4b1d-b4f3-c8e53c13b216" />
